### PR TITLE
Fix testRegex to not include .snap files

### DIFF
--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -24,12 +24,12 @@ const runTests = (serverless, options) => new BbPromise((resolve, reject) => {
 
       if (functionName) {
         if (allFunctions.indexOf(functionName) >= 0) {
-          Object.assign(config, { testRegex: `${functionName}\\.test\\.js` });
+          Object.assign(config, { testRegex: `${functionName}\\.test\\.js$` });
         } else {
           return reject(`Function "${functionName}" not found`);
         }
       } else {
-        const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js`).join('|');
+        const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js$`).join('|');
         Object.assign(config, { testRegex: functionsRegex });
       }
 


### PR DESCRIPTION
The `testRegex` now ensures that only `.test.js` files are run, rather than files which happen to contain `.test.js` (such as Jest snapshots)