### PR TITLE
Adding custom options to jest execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ Add the plugin to `serverless.yml`:
 ```yml
 plugins:
   - serverless-jest-plugin
+custom:
+  jest:
+    # You can pass jest options here
+    # See details here: https://facebook.github.io/jest/docs/configuration.html
+    # For instance, uncomment next line to enable code coverage
+    # collectCoverage: true
 ```
 
 ## Usage

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ const runTests = require('./lib/run-tests');
 class ServerlessJestPlugin {
   constructor(serverless, options) {
     this.serverless = serverless;
+    this.service = serverless.service || {};
+    this.config = (this.service.custom && this.service.custom.jest) || {};
     this.options = options;
     this.commands = {
       create: {
@@ -89,7 +91,7 @@ class ServerlessJestPlugin {
           .then(() => createTest(this.serverless, this.options)),
       'invoke:test:test': () =>
         BbPromise.bind(this)
-          .then(() => runTests(this.serverless, this.options)),
+          .then(() => runTests(this.serverless, this.options, this.config)),
       'create:function:create': () =>
         BbPromise.bind(this)
           .then(() => createFunction(this.serverless, this.options))

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -4,12 +4,10 @@ const runCLI = require('jest').runCLI;
 const BbPromise = require('bluebird');
 const { setEnv } = require('./utils');
 
-const runTests = (serverless, options) => new BbPromise((resolve, reject) => {
+const runTests = (serverless, options, conf) => new BbPromise((resolve, reject) => {
   const functionName = options.function;
   const allFunctions = serverless.service.getAllFunctions();
-  const config = {
-    testEnvironment: 'node',
-  };
+  const config = Object.assign({ testEnvironment: 'node' }, conf);
 
   const vars = new serverless.classes.Variables(serverless);
   vars.populateService(options);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-jest-plugin",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Serverless plugin for test driven development using Jest",
   "main": "index.js",
   "author": "Eetu Tuomala (https://sc5.io)",


### PR DESCRIPTION
This PR aims to allow passing options to jest execution.
You can define these options in `custom.jest` in `serverless.yml`.
Options are defined here: https://facebook.github.io/jest/docs/configuration.html
Let me know if you have some remarks