### PR TITLE
FIX: Update template to meet Lambda Wrapper's example

### DIFF
--- a/lib/templates/test-template.ejs
+++ b/lib/templates/test-template.ejs
@@ -17,7 +17,7 @@ describe('<%= functionName %>', () => {
   });
 
   it('implement tests here', () => {
-    return wrapped.run({}).then((response) => {
+    return wrapped.run({}, (response) => {
       expect(response).toBeDefined();
     });
   });


### PR DESCRIPTION
With the previous template Jest test would exit 0 and bypass all tests.

This change is in line with https://github.com/SC5/lambda-wrapper example, and Jest test cases are functioning again