### PR TITLE
Fixing Issue #21 -  Adding aws-nodejs8.10 to supported runtime list.

### DIFF
--- a/lib/create-function.js
+++ b/lib/create-function.js
@@ -11,6 +11,7 @@ const functionTemplateFile = path.join('templates', 'function-template.ejs');
 const validFunctionRuntimes = [
   'aws-nodejs4.3',
   'aws-nodejs6.10',
+  'aws-nodejs8.10',
 ];
 
 const humanReadableFunctionRuntimes = `${validFunctionRuntimes


### PR DESCRIPTION
This pull request adds nodejs810 to the supported runtime list, resolving Issue #21 