### PR TITLE
Fix for serverless.yml jest configuration not being honored

### DIFF
--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -1,0 +1,186 @@
+'use strict';
+
+const fs = require('fs-extra');
+const jestConfig = require('jest-config');
+const path = require('path');
+const Serverless = require('serverless');
+const testUtils = require('./test-utils');
+
+jest.mock('serverless/lib/classes/CLI', () =>
+  jest.fn().mockImplementation((serverless) => {
+    const CLI = jest.requireActual('serverless/lib/classes/CLI');
+    return new CLI(serverless, ['invoke', 'test']);
+  }),
+);
+
+describe('jest configuration', () => {
+  beforeAll(() => {
+    process.env.PLUGIN_TEST_DIR = path.join(__dirname);
+  });
+
+  beforeEach(() => {
+    jest.spyOn(jestConfig, 'readConfig');
+
+    const tmp = testUtils.getTmpDirPath();
+    fs.ensureDirSync(tmp);
+    process.chdir(tmp);
+    fs.ensureDirSync('__tests__');
+
+    fs.writeFileSync(
+      'package.json',
+      `{
+        "name": "application-name-4",
+        "version": "0.0.1",
+        "dependencies": {
+          "serverless-jest-plugin": "file:${process.env.PLUGIN_TEST_DIR}"
+        },
+        "devDependencies": {
+          "serverless": "^1.32.0"
+        }
+      }`,
+    );
+
+    fs.writeFileSync(
+      'handler.js',
+      `'use strict';
+
+      module.exports.hello = (event, context, callback) => {
+        const response = {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'Go Serverless v1.0! Your function executed successfully!',
+            input: event,
+          }),
+        };
+      
+        callback(null, response);
+      
+        // Use this code if you don't use the http event with the LAMBDA-PROXY integration
+        // callback(null, { message: 'Go Serverless v1.0! Your function executed successfully!', event });
+      };`,
+    );
+
+    fs.writeFileSync(
+      '__tests__/hello.test.js',
+      `
+      const jestPlugin = require('${process.env.PLUGIN_TEST_DIR}/..');
+      const wrapped = jestPlugin.getWrapper('handler', '/handler.js', 'hello');
+
+      describe('hello', () => {
+        it('runs the test', async () => {
+          const result = await wrapped.run({});
+          expect(result).toBeDefined();
+        });
+      });
+      `,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    // remove temp dir
+    fs.removeSync(process.cwd());
+  });
+
+  afterAll(() => {
+    process.chdir(process.env.PLUGIN_TEST_DIR);
+  });
+
+  it('passes the serverless jest config through to jest', async () => {
+    fs.writeFileSync(
+      'serverless.yml',
+      `
+      service: my-service
+      provider:
+        name: aws
+        runtime: nodejs8.10
+      plugins:
+        - serverless-jest-plugin
+      custom:
+        jest:
+          verbose: false
+          collectCoverage: true
+          useStderr: true
+      functions:
+        hello:
+          handler: handler.hello
+      `,
+    );
+
+    expect(fs.existsSync('coverage')).toBeFalsy();
+
+    const serverless = new Serverless({ interactive: false });
+    await serverless.init();
+
+    expect(serverless).toHaveProperty('service.custom.jest.verbose', false);
+    expect(serverless).toHaveProperty('service.custom.jest.collectCoverage', true);
+    expect(serverless).toHaveProperty('service.custom.jest.useStderr', true);
+
+    try {
+      await serverless.run();
+    } catch (err) {
+      console.error(err);
+    }
+
+    expect(jestConfig.readConfig).toHaveBeenCalled();
+
+    const [[globalConfig, servicePath], ...rest] = jestConfig.readConfig.mock.calls;
+
+    expect(globalConfig).toBeDefined();
+    expect(globalConfig).toMatchObject({
+      verbose: false,
+      collectCoverage: true,
+      useStderr: true,
+    });
+    expect(fs.existsSync('coverage')).toBeTruthy();
+  });
+
+  it('modifies the serverless jest config and verifies the changes', async () => {
+    fs.writeFileSync(
+      'serverless.yml',
+      `
+      service: my-service
+      provider:
+        name: aws
+        runtime: nodejs8.10
+      plugins:
+        - serverless-jest-plugin
+      custom:
+        jest:
+          verbose: true
+          collectCoverage: false
+          useStderr: true
+      functions:
+        hello:
+          handler: handler.hello
+      `,
+    );
+
+    expect(fs.existsSync('coverage')).toBeFalsy();
+
+    const serverless = new Serverless({ interactive: false });
+    await serverless.init();
+
+    expect(serverless).toHaveProperty('service.custom.jest.verbose', true);
+    expect(serverless).toHaveProperty('service.custom.jest.collectCoverage', false);
+    expect(serverless).toHaveProperty('service.custom.jest.useStderr', true);
+
+    try {
+      await serverless.run();
+    } catch (err) {
+      console.error(err);
+    }
+
+    expect(jestConfig.readConfig).toHaveBeenCalled();
+
+    const [[globalConfig, servicePath], ...rest] = jestConfig.readConfig.mock.calls;
+
+    expect(globalConfig).toBeDefined();
+    expect(globalConfig).toMatchObject({
+      verbose: true,
+      collectCoverage: false,
+      useStderr: true,
+    });
+    expect(fs.existsSync('coverage')).toBeFalsy();
+  });
+});

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -84,6 +84,7 @@ describe('jest configuration', () => {
 
   afterAll(() => {
     process.chdir(process.env.PLUGIN_TEST_DIR);
+    jest.unmock('serverless/lib/classes/CLI');
   });
 
   it('passes the serverless jest config through to jest', async () => {

--- a/__tests__/integration-options.test.js
+++ b/__tests__/integration-options.test.js
@@ -18,16 +18,12 @@ describe('integration', () => {
   beforeAll(() => {
     process.env.PLUGIN_TEST_DIR = path.join(__dirname);
     const tmpDir = getTmpDirPath();
-    const tmpLocalDir = path.join(tmpDir, '.local');
     fs.mkdirsSync(tmpDir);
     fs.copySync(path.join(process.env.PLUGIN_TEST_DIR, 'test-service-options'), tmpDir);
-    fs.copySync(path.join(process.env.PLUGIN_TEST_DIR, '..'), tmpLocalDir);
-    // Remove the tests that were copied over to prevent the subprocess from re-running them
-    fs.removeSync(path.join(tmpLocalDir, '__tests__'));
     const packageJsonPath = path.join(tmpDir, 'package.json');
     const packageJson = fs.readJsonSync(packageJsonPath);
     packageJson.name = `application-${Date.now()}`;
-    packageJson.dependencies['serverless-jest-plugin'] = `file:${tmpDir}/.local`;
+    packageJson.dependencies['serverless-jest-plugin'] = `file:${process.env.PLUGIN_TEST_DIR}`;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
     process.chdir(tmpDir);
   });

--- a/__tests__/integration6.10.test.js
+++ b/__tests__/integration6.10.test.js
@@ -18,16 +18,12 @@ describe('integration', () => {
   beforeAll(() => {
     process.env.PLUGIN_TEST_DIR = path.join(__dirname);
     const tmpDir = getTmpDirPath();
-    const tmpLocalDir = path.join(tmpDir, '.local');
     fs.mkdirsSync(tmpDir);
     fs.copySync(path.join(process.env.PLUGIN_TEST_DIR, 'test-service6.10'), tmpDir);
-    fs.copySync(path.join(process.env.PLUGIN_TEST_DIR, '..'), tmpLocalDir);
-    // Remove the tests that were copied over to prevent the subprocess from re-running them
-    fs.removeSync(path.join(tmpLocalDir, '__tests__'));
     const packageJsonPath = path.join(tmpDir, 'package.json');
     const packageJson = fs.readJsonSync(packageJsonPath);
     packageJson.name = `application-${Date.now()}`;
-    packageJson.dependencies['serverless-jest-plugin'] = `file:${tmpDir}/.local`;
+    packageJson.dependencies['serverless-jest-plugin'] = `file:${process.env.PLUGIN_TEST_DIR}`;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
     process.chdir(tmpDir);
   });

--- a/__tests__/integration8.10.test.js
+++ b/__tests__/integration8.10.test.js
@@ -15,15 +15,11 @@ describe('integration', () => {
     process.env.PLUGIN_TEST_DIR = path.join(__dirname);
     const tmpDir = getTmpDirPath();
     fs.mkdirsSync(tmpDir);
-    const tmpLocalDir = path.join(tmpDir, '.local');
     fs.copySync(path.join(process.env.PLUGIN_TEST_DIR, 'test-service8.10'), tmpDir);
-    fs.copySync(path.join(process.env.PLUGIN_TEST_DIR, '..'), tmpLocalDir);
-    // Remove the tests that were copied over to prevent the subprocess from re-running them
-    fs.removeSync(path.join(tmpLocalDir, '__tests__'));
     const packageJsonPath = path.join(tmpDir, 'package.json');
     const packageJson = fs.readJsonSync(packageJsonPath);
     packageJson.name = `application-${Date.now()}`;
-    packageJson.dependencies['serverless-jest-plugin'] = `file:${tmpDir}/.local`;
+    packageJson.dependencies['serverless-jest-plugin'] = `file:${process.env.PLUGIN_TEST_DIR}`;
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson));
     process.chdir(tmpDir);
   });

--- a/lib/create-test.js
+++ b/lib/create-test.js
@@ -58,7 +58,7 @@ const createTest = (serverless, options) => {
     testFilePath,
   };
 
-  testfileNotExists(testConfig)
+  return testfileNotExists(testConfig)
     .then(() => writeTestfile(serverless, options, testConfig))
     .then(() => serverless.cli.log(`Created test file ${testFilePath}`))
     .catch((error) => {

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -29,7 +29,7 @@ const runTests = (serverless, options, conf) =>
     // eslint-disable-next-line dot-notation
     process.env['SERVERLESS_TEST_ROOT'] = serverless.config.servicePath;
 
-    return runCLI({ config }, [serverless.config.servicePath]).then(success => resolve(success));
+    return runCLI(config, [serverless.config.servicePath]).then(success => resolve(success));
   });
 
 module.exports = runTests;

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -29,7 +29,9 @@ const runTests = (serverless, options, conf) =>
     // eslint-disable-next-line dot-notation
     process.env['SERVERLESS_TEST_ROOT'] = serverless.config.servicePath;
 
-    return runCLI(config, [serverless.config.servicePath]).then(success => resolve(success));
+    return runCLI(config, [serverless.config.servicePath])
+      .then((...success) => resolve(...success))
+      .catch(e => reject(e));
   });
 
 module.exports = runTests;

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -29,7 +29,7 @@ const runTests = (serverless, options, conf) =>
     // eslint-disable-next-line dot-notation
     process.env['SERVERLESS_TEST_ROOT'] = serverless.config.servicePath;
 
-    return runCLI({ config }, [serverless.config.servicePath], success => resolve(success));
+    return runCLI({ config }, [serverless.config.servicePath]).then(success => resolve(success));
   });
 
 module.exports = runTests;


### PR DESCRIPTION
Fixes #24

There were essentially two issues with the upgrade to Jest v23:
  - The settings within `serverless.yml` were not being passed through to Jest properly due to the changes to `jest-cli`
  - The promise from the `runTests` method was not resolving properly due to (surprise!) the method signature changes to `jest-cli`

I added two tests to explicitly verify that the settings within `serverless.yml` are making it through to `jest-config` as expected, so that should (in theory) help avoid something like this happening in the future.

I found that creating the necessary files for the tests on-the-fly seemed to be faster than the heavier copy-paste operations from some of the other tests.