### PR TITLE
Support overriding testRegex setting and running all Jest tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ sls create test -f functionName
 Tests can be run directly using Jest or using the "invoke test" command
 
 ```
-sls invoke test [--stage stage] [--region region] [-f function]
+sls invoke test [--stage stage] [--region region] [-f function] [--all]
 ```
 
 If no function names are passed to "invoke test", all tests related to handler functions are run.
+
+If `--all` or `-A` is passed to "invoke test", all tests are run.
 
 ## License
 https://github.com/SC5/serverless-jest-plugin/blob/master/LICENSE

--- a/__tests__/config.test.js
+++ b/__tests__/config.test.js
@@ -15,6 +15,24 @@ jest.mock('serverless/lib/classes/CLI', () =>
   }),
 );
 
+const writeServerlessConfig = (jestOptions) => {
+  const serverlessConfig = `
+  service: my-service
+  provider:
+    name: aws
+    runtime: nodejs8.10
+  plugins:
+    - serverless-jest-plugin
+  custom:
+    jest:
+      ${jestOptions}
+  functions:
+    hello:
+      handler: handler.hello
+  `;
+  fs.writeFileSync('serverless.yml', serverlessConfig);
+};
+
 describe('jest configuration', () => {
   beforeAll(() => {
     process.env.PLUGIN_TEST_DIR = path.join(__dirname);
@@ -92,24 +110,10 @@ describe('jest configuration', () => {
   });
 
   it('passes the serverless jest config through to jest', () => {
-    fs.writeFileSync(
-      'serverless.yml',
-      `
-      service: my-service
-      provider:
-        name: aws
-        runtime: nodejs8.10
-      plugins:
-        - serverless-jest-plugin
-      custom:
-        jest:
-          verbose: false
-          collectCoverage: true
-          useStderr: true
-      functions:
-        hello:
-          handler: handler.hello
-      `,
+    writeServerlessConfig(
+      `verbose: false
+      collectCoverage: true
+      useStderr: true`,
     );
 
     expect(fs.existsSync('coverage')).toBeFalsy();
@@ -143,24 +147,10 @@ describe('jest configuration', () => {
   }, 10000);
 
   it('modifies the serverless jest config and verifies the changes', () => {
-    fs.writeFileSync(
-      'serverless.yml',
-      `
-      service: my-service
-      provider:
-        name: aws
-        runtime: nodejs8.10
-      plugins:
-        - serverless-jest-plugin
-      custom:
-        jest:
-          verbose: true
-          collectCoverage: false
-          useStderr: true
-      functions:
-        hello:
-          handler: handler.hello
-      `,
+    writeServerlessConfig(
+      `verbose: true
+      collectCoverage: false
+      useStderr: true`,
     );
 
     expect(fs.existsSync('coverage')).toBeFalsy();
@@ -197,23 +187,9 @@ describe('jest configuration', () => {
   it('allows testRegex to be changed', () => {
     const regex = '(/__tests__/.*|(\\.|/)(test|spec))\\.jsx?$';
 
-    fs.writeFileSync(
-      'serverless.yml',
-      `
-      service: my-service
-      provider:
-        name: aws
-        runtime: nodejs8.10
-      plugins:
-        - serverless-jest-plugin
-      custom:
-        jest:
-          useStderr: true
-          testRegex: ${regex}
-      functions:
-        hello:
-          handler: handler.hello
-      `,
+    writeServerlessConfig(
+      `useStderr: true
+      testRegex: ${regex}`,
     );
 
     const serverless = new Serverless({ interactive: false });
@@ -241,23 +217,9 @@ describe('jest configuration', () => {
   }, 10000);
 
   it('can test all test files, not just function-related ones', () => {
-    fs.writeFileSync(
-      'serverless.yml',
-      `
-      service: my-service
-      provider:
-        name: aws
-        runtime: nodejs8.10
-      plugins:
-        - serverless-jest-plugin
-      custom:
-        jest:
-          verbose: true
-          useStderr: true
-      functions:
-        hello:
-          handler: handler.hello
-      `,
+    writeServerlessConfig(
+      `verbose: true
+      useStderr: true`,
     );
 
     fs.writeFileSync(
@@ -279,28 +241,48 @@ describe('jest configuration', () => {
 
     return serverless
       .init()
-      .then(() => {
-        expect(serverless).toHaveProperty('service.custom.jest.verbose', true);
-        expect(serverless).toHaveProperty('service.custom.jest.useStderr', true);
-
-        return serverless.run();
-      })
+      .then(() => serverless.run())
       .catch(err => expect(err).toBeUndefined())
       .then((...serverlessResults) => {
         const [{ results }] = serverlessResults;
-        expect(jestConfig.readConfig).toHaveBeenCalled();
-
-        const [[globalConfig]] = jestConfig.readConfig.mock.calls;
-
-        expect(globalConfig).toBeDefined();
-        expect(globalConfig).toMatchObject({
-          verbose: true,
-          useStderr: true,
-        });
 
         expect(results).toBeDefined();
         expect(results).toHaveProperty('numTotalTestSuites');
         expect(results.numTotalTestSuites).toBe(2);
+      });
+  }, 10000);
+
+  it('will ignore other test files by default', () => {
+    writeServerlessConfig(
+      `verbose: true
+      useStderr: true`,
+    );
+
+    fs.writeFileSync(
+      '__tests__/utils.test.js',
+      `
+      describe('random test', () => {
+        it('runs the test', () => {
+          expect(true).toBeTruthy();
+        });
+      });
+      `,
+    );
+
+    const serverless = new Serverless({ interactive: false });
+
+    expect.hasAssertions();
+
+    return serverless
+      .init()
+      .then(() => serverless.run())
+      .catch(err => expect(err).toBeUndefined())
+      .then((...serverlessResults) => {
+        const [{ results }] = serverlessResults;
+
+        expect(results).toBeDefined();
+        expect(results).toHaveProperty('numTotalTestSuites');
+        expect(results.numTotalTestSuites).toBe(1);
       });
   }, 10000);
 });

--- a/index.js
+++ b/index.js
@@ -71,6 +71,10 @@ class ServerlessJestPlugin {
                 usage: 'Options for jest reporter',
                 shortcut: 'O',
               },
+              all: {
+                usage: 'Run all discovered Jest tests',
+                shortcut: 'A',
+              },
               path: {
                 usage: 'Path for the tests for running tests in other than default "test" folder',
               },

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -8,7 +8,7 @@ const runTests = (serverless, options, conf) =>
   new BbPromise((resolve, reject) => {
     const functionName = options.function;
     const allFunctions = serverless.service.getAllFunctions();
-    const config = Object.assign({ testEnvironment: 'node' }, conf);
+    let config = Object.assign({ testEnvironment: 'node' }, conf);
 
     const vars = new serverless.classes.Variables(serverless);
     vars.populateService(options);
@@ -23,7 +23,7 @@ const runTests = (serverless, options, conf) =>
       }
     } else {
       const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js$`).join('|');
-      Object.assign(config, { testRegex: functionsRegex });
+      config = Object.assign({}, { testRegex: functionsRegex }, config);
     }
 
     // eslint-disable-next-line dot-notation

--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -21,7 +21,7 @@ const runTests = (serverless, options, conf) =>
       } else {
         return reject(`Function "${functionName}" not found`);
       }
-    } else {
+    } else if (!options.all) {
       const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js$`).join('|');
       config = Object.assign({}, { testRegex: functionsRegex }, config);
     }


### PR DESCRIPTION
Fixes #26 

These changes enable you to specify `testRegex` within `serverless.yml` in order to provide a custom expression if needed (while still maintaining the existing, default behavior if not provided).

Additionally, it adds the `--all, -A` command line argument to the `invoke test` command to allow Jest to test any discovered tests, not simply those matching the `${functionName}.test.js` pattern.