### PR TITLE
allow custom testRegex

### DIFF
--- a/lib/run-tests.js
+++ b/lib/run-tests.js
@@ -14,16 +14,18 @@ const runTests = (serverless, options, conf) =>
     vars.populateService(options);
     allFunctions.forEach(name => setEnv(serverless, name));
 
-    if (functionName) {
-      if (allFunctions.indexOf(functionName) >= 0) {
-        setEnv(serverless, functionName);
-        Object.assign(config, { testRegex: `${functionName}\\.test\\.js$` });
+    if (!config.testRegex) {
+      if (functionName) {
+        if (allFunctions.indexOf(functionName) >= 0) {
+          setEnv(serverless, functionName);
+          Object.assign(config, { testRegex: `${functionName}\\.test\\.js$` });
+        } else {
+          return reject(`Function "${functionName}" not found`);
+        }
       } else {
-        return reject(`Function "${functionName}" not found`);
+        const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js$`).join('|');
+        Object.assign(config, { testRegex: functionsRegex });
       }
-    } else {
-      const functionsRegex = allFunctions.map(name => `${name}\\.test\\.js$`).join('|');
-      Object.assign(config, { testRegex: functionsRegex });
     }
 
     // eslint-disable-next-line dot-notation


### PR DESCRIPTION
Fixes #26

ignore testRegex generation based on functionName if custom.jest.testRegex is already defined

usage:

```
custom:
  jest:
    testRegex: (/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$
```