### PR TITLE
Add aws-nodejs10.x as allowed runtime

### DIFF
--- a/lib/create-function.js
+++ b/lib/create-function.js
@@ -12,6 +12,7 @@ const validFunctionRuntimes = [
   'aws-nodejs4.3',
   'aws-nodejs6.10',
   'aws-nodejs8.10',
+  'aws-nodejs10.x'
 ];
 
 const humanReadableFunctionRuntimes = `${validFunctionRuntimes

--- a/lib/create-function.js
+++ b/lib/create-function.js
@@ -12,7 +12,7 @@ const validFunctionRuntimes = [
   'aws-nodejs4.3',
   'aws-nodejs6.10',
   'aws-nodejs8.10',
-  'aws-nodejs10.x'
+  'aws-nodejs10.x',
 ];
 
 const humanReadableFunctionRuntimes = `${validFunctionRuntimes


### PR DESCRIPTION
I'm not 100 percent if this is correct, but we can't use the `create function` call as we are on the nodejs10.x runtime.

Verified this works by manually modifying content in the `node_modules`.